### PR TITLE
Use framework instead of deprecated com.google.playservices

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,6 +27,7 @@
 	  	<param name="android-package" value="com.ccsoft.plugin.AndroidEmail" />
 	  </feature>		
 	</config-file>    
-	<dependency id="com.google.playservices" />
-     </platform>          
+
+	<framework src="com.google.android.gms:play-services-identity:+" />
+    </platform>          
 </plugin>

--- a/src/android/AndroidEmail.java
+++ b/src/android/AndroidEmail.java
@@ -17,7 +17,7 @@ public class AndroidEmail extends CordovaPlugin {
 	private final String TAG = "AndroidEmail";
 	private static final int REQUEST_CODE_EMAIL = 1;
 	private CallbackContext _callbackContext = null;
-		
+	
     @Override
     public boolean execute(String action, JSONArray args,
 			final CallbackContext callbackContext) throws JSONException {
@@ -30,7 +30,7 @@ public class AndroidEmail extends CordovaPlugin {
     			public void run() {
     				try {
     	    	        Intent intent = AccountPicker.newChooseAccountIntent(null, null,
-    	    	                new String[] { GoogleAuthUtil.GOOGLE_ACCOUNT_TYPE }, false, null, null, null, null);
+    	    	                new String[] { GoogleAuthUtil.GOOGLE_ACCOUNT_TYPE }, true, null, null, null, null);
     	    	        cordova.getActivity().startActivityForResult(intent, REQUEST_CODE_EMAIL);
     	    	    } catch (ActivityNotFoundException e) {
     	    	       	Log.e(TAG, "Activity not found: " + e.toString() );


### PR DESCRIPTION
Use of deprecated com.google.playservices creates problem when used with some other plugins. Use of framework fixes them.